### PR TITLE
Support author field and relative file path for html report

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -144,6 +144,12 @@ def add_arguments_to_parser(parser):
                                   "Note: baseline files must have extension "
                                   "'.baseline'.")
 
+    output_opts.add_argument('-r', '--relative-path-with-root-dir',
+                             dest="relative_path_with_root_dir",
+                             required=False,
+                             help="Root directory to create relative file path\n"
+                                  "for generated reports")
+
     parser.add_argument('--suppress',
                         type=str,
                         dest="suppress",
@@ -383,12 +389,15 @@ def main(args):
     processed_path_hashes = set()
     processed_file_paths = set()
     print_steps = 'print_steps' in args
+    relative_path_with_root_dir = args.relative_path_with_root_dir if 'relative_path_with_root_dir' in args else None
 
     html_builder: Optional[report_to_html.HtmlBuilder] = None
     if export == 'html':
         html_builder = report_to_html.HtmlBuilder(
             context.path_plist_to_html_dist,
-            context.checker_labels)
+            context.checker_labels,
+            relative_path_with_root_dir=relative_path_with_root_dir
+        )
 
     for dir_path, file_paths in report_file.analyzer_result_files(args.input):
         metadata = get_metadata(dir_path)

--- a/tools/report-converter/codechecker_report_converter/report/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/report/__init__.py
@@ -282,6 +282,7 @@ class Report:
         message: str,
         checker_name: str,
         severity: Optional[str] = None,
+        author: Optional[str] = None,
         report_hash: Optional[str] = None,
         analyzer_name: Optional[str] = None,
         category: Optional[str] = None,
@@ -301,6 +302,7 @@ class Report:
         self.message = message
         self.checker_name = checker_name
         self.severity = severity
+        self.author = author
         self.report_hash = report_hash
         self.analyzer_name = analyzer_name
         self.category = category

--- a/tools/report-converter/codechecker_report_converter/report/output/html/html.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/html.py
@@ -107,12 +107,14 @@ class HtmlBuilder:
     def __init__(
         self,
         layout_dir: str,
-        checker_labels: Optional[CheckerLabels] = None
+        checker_labels: Optional[CheckerLabels] = None,
+        relative_path_with_root_dir: str = None
     ):
         self._checker_labels = checker_labels
         self.layout_dir = layout_dir
         self.generated_html_reports: Dict[str, HTMLReports] = {}
         self.files: FileSources = {}
+        self.relative_path_with_root_dir = relative_path_with_root_dir
 
         css_dir = os.path.join(self.layout_dir, 'css')
         js_dir = os.path.join(self.layout_dir, 'js')
@@ -367,7 +369,10 @@ class HtmlBuilder:
 
                 rs = review_status.lower().replace(' ', '-')
                 file_path = self.files[report['fileId']]['filePath']
-
+                if self.relative_path_with_root_dir:
+                    relative_path = os.path.relpath(file_path, self.relative_path_with_root_dir)
+                    file_path = os.path.normpath(relative_path)
+                
                 checker = report['checker']
                 doc_url = checker.get('url')
                 if doc_url:

--- a/tools/report-converter/codechecker_report_converter/report/output/html/static/js/buglist.js
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/static/js/buglist.js
@@ -63,6 +63,7 @@ var BugList = {
            columnId === 'checker-name' ||
            columnId === 'message' ||
            columnId === 'bug-path-length' ||
+           columnId === 'author' ||
            columnId === 'review-status';
   },
 

--- a/tools/report-converter/codechecker_report_converter/report/parser/plist.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/plist.py
@@ -246,6 +246,7 @@ class Parser(BaseParser):
         if severity == None:
             severity = self.get_severity(checker_name)
 
+        author = diag.get('author', 'unknown')
         report_annotation = diag["report-annotation"] \
             if "report-annotation" in diag else None
 
@@ -257,6 +258,7 @@ class Parser(BaseParser):
             message=diag.get('description', ''),
             checker_name=checker_name,
             severity=severity,
+            author=author,
             report_hash=diag.get('issue_hash_content_of_line_in_context'),
             analyzer_name=analyzer_name,
             category=diag.get('category'),
@@ -508,6 +510,9 @@ class Parser(BaseParser):
 
             if report.severity:
                 diagnostic['severity'] = report.severity
+
+            if report.author:
+                diagnostic['author'] = report.author
 
             if report.analyzer_name:
                 diagnostic['type'] = report.analyzer_name


### PR DESCRIPTION
- New `author` field for a report and html (using `git blame`)
- New option added to CLI: Export HTML report with relative file path